### PR TITLE
Fix NotificationSystem.VRModeSwitched()

### DIFF
--- a/TotallyWholesome/Notification/NotificationSystem.cs
+++ b/TotallyWholesome/Notification/NotificationSystem.cs
@@ -91,9 +91,9 @@ namespace TotallyWholesome.Notification
             }
             
             if(MetaPort.Instance.isUsingVr)
-                _hudContent = PlayerSetup.Instance.desktopCamera.GetComponentInChildren<Canvas>().gameObject;
-            else
                 _hudContent = PlayerSetup.Instance.vrCamera.GetComponentInChildren<Canvas>().gameObject;
+            else
+                _hudContent = PlayerSetup.Instance.desktopCamera.GetComponentInChildren<Canvas>().gameObject;
 
             _notificationGO.transform.parent = _hudContent.transform;
             


### PR DESCRIPTION
MetaPort.Instance.isUsingVr is set to proper VRMode before avatar switch. 

Avatar switch must be last due to avatar initialization depending on many other systems being set to VRMode or not. 
(camera, IK, calibration, ect)

*all i did was swap two lines*