### PR TITLE
Various fixes to strings, user settings and pishock

### DIFF
--- a/TotallyWholesome/Managers/ConfigManager.cs
+++ b/TotallyWholesome/Managers/ConfigManager.cs
@@ -276,7 +276,7 @@ namespace TotallyWholesome.Managers
 
         [Access(Category = "SettingsGeneral", Name = "Private Leash",
             DescriptionGlobal = "Only you and your Pets/Masters will see the Leash",
-            DescriptionUser = "Only you and this Pets/Masters will see the Leash",
+            DescriptionUser = "Only you and this Pet/Master will see the Leash",
             Global = true, User = true,
             DialogMessageGlobal = "Changing Private Leash will not apply until you clear and create new leashes!",
             DialogMessageUser = "Changing Private Leash will not apply until you clear create it again!")]
@@ -328,14 +328,14 @@ namespace TotallyWholesome.Managers
 
         [Access(Category = "SettingsPet", Name = "Allow Force Mute",
             DescriptionGlobal = "This will allow all masters to mute you",
-            DescriptionUser = "This will allow this masters to mute you",
+            DescriptionUser = "This will allow this master to mute you",
             Global = true, User = true,
             DialogMessageGlobal = "Allowing Force Mute will allow your master to mute you at any time! You can disable this setting to unlock it.",
             DialogMessageUser = "Allowing Force Mute will allow your master to mute you at any time! You can disable this setting to unlock it.", FeatureEnum = NetworkedFeature.AllowForceMute)]
         AllowForceMute = 0x1002,
 
         //TODO: MAKE THIS WORK AGAIN AAAAA
-        /*[Access(Category = "Pet", Name = "Enable Muffled Mode",
+        /*[Access(Category = "SettingsPet", Name = "Enable Muffled Mode",
             DescriptionGlobal = "Instead of muted you will be muffled",
             Global = true, User = false)]
         EnableMuffledMode = 0x1003,*/
@@ -347,7 +347,7 @@ namespace TotallyWholesome.Managers
 
         [Access(Category = "SettingsPet", Name = "Allow Toy Control",
             DescriptionGlobal = "This will allow all masters to control your Toys",
-            DescriptionUser = "This will allow this masters to control your Toys",
+            DescriptionUser = "This will allow this master to control your Toys",
             Global = true, User = true,
             DialogMessageGlobal = "Allowing Toy Control will allow your master to control your connected toys! You can disable this setting to reset it.",
             DialogMessageUser = "Allowing Toy Control will allow your master to control your connected toys! You can disable this setting to reset it.", FeatureEnum = NetworkedFeature.AllowToyControl)]
@@ -370,19 +370,19 @@ namespace TotallyWholesome.Managers
         AllowBlindfolding = 0x1009,
         [Access(Category = "SettingsPet", Name = "Allow Deafening", DescriptionGlobal = "Allows all masters to deafen you!", DescriptionUser = "Allows this master to deafen you!", Global = true, User = true, FeatureEnum = NetworkedFeature.AllowDeafening)]
         AllowDeafening = 0x1010,
-        [Access(Category = "SettingsPet", Name = "Allow Switching to Any Avatar", DescriptionGlobal = "Allows this master to change you into ANY avatar that you can access, you should be mindful of who can do this!", DescriptionUser = "Allows this master to change you into ANY avatar that you can access, you should be mindful of who can do this!", Global = true, User = true, FeatureEnum = NetworkedFeature.AllowAnyAvatarSwitching, ConfirmPrompt = true, DialogMessageGlobal = "Enabling this will allow ANY master to change you into ANY avatar! Please be careful enabling this in instances where NSFW content isn't allowed!", DialogMessageUser = "Enabling this will allow this master to change you into ANY avatar! Please be careful about allowing usage of this in instances where NSFW content isn't allowed!")]
+        [Access(Category = "SettingsPet", Name = "Allow Switching to Any Avatar", DescriptionGlobal = "Allows all masters to change you into ANY avatar that you can access, you should be mindful of who can do this!", DescriptionUser = "Allows this master to change you into ANY avatar that you can access, you should be mindful of who can do this!", Global = true, User = true, FeatureEnum = NetworkedFeature.AllowAnyAvatarSwitching, ConfirmPrompt = true, DialogMessageGlobal = "Enabling this will allow ANY master to change you into ANY avatar! Please be careful enabling this in instances where NSFW content isn't allowed!", DialogMessageUser = "Enabling this will allow this master to change you into ANY avatar! Please be careful about allowing usage of this in instances where NSFW content isn't allowed!")]
         AllowAnyAvatarSwitch = 0x1011,
 
         [Access(Category = "SettingsMaster", Name = "Allow Pet to follow you",
             DescriptionGlobal = "This will allow all pets to follow you on World change",
-            DescriptionUser = "This will allow this pets to follow you on World change",
+            DescriptionUser = "This will allow this pet to follow you on World change",
             Global = true, User = false,
             DialogMessageGlobal = "Send World Change to Pet will send enough information for your pet to join your instance, this applies to any instance type.")]
         AllowPetWorldChangeFollow = 0x2002,
 
         [Access(Category = "SettingsMaster", Name = "Auto Accept Master Requests",
             DescriptionGlobal = "This will allow all pets to make you their master automatically",
-            DescriptionUser = "This will allow this pets to make you their master automatically",
+            DescriptionUser = "This will allow this pet to make you their master automatically",
             Global = true, User = true,
             DialogMessageGlobal = "Are you sure you want to enable this? This will allow ANYONE to make you their master!",
             DialogMessageUser = "Are you sure you want to enable this? This will allow this user to make you their master without confirmation!",

--- a/TotallyWholesome/Managers/Shockers/PiShock/PiShockManager.cs
+++ b/TotallyWholesome/Managers/Shockers/PiShock/PiShockManager.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Drawing;
 using System.Net;
 using System.Net.Http;
@@ -172,7 +173,11 @@ public class PiShockManager : IShockerProvider, IAsyncDisposable
     {
         var piShockOperation = PiShockUtils.OperationTranslation[type];
 
-        foreach (var (key, value) in PiShockConfig.Config.Shockers)
+        var selectedShockers = PiShockConfig.Config.Shockers.Where(x => x.Value.Enabled).ToArray();
+        if (ConfigManager.Instance.IsActiveCurrent(AccessType.ShockRandomShocker) && selectedShockers.Length > 0)
+            selectedShockers = [selectedShockers[new Random().Next(0, selectedShockers.Length)]];
+
+        foreach (var (key, value) in selectedShockers)
         {
             if (!_shockerInfoCache.TryGetValue(key, out var shockerInfo))
             {

--- a/TotallyWholesome/Managers/TWUI/Pages/IndividualPetControl.cs
+++ b/TotallyWholesome/Managers/TWUI/Pages/IndividualPetControl.cs
@@ -48,7 +48,7 @@ public class IndividualPetControl : ITWManager
     private Category _generatedSliderFloats;
     private Page _avatarSwitchingPage;
     private Category _petAvatarListCat;
-    private Button _openAvatarSwitch, _removeLeashes, _beep, _vibrate, _shock, _switchToMyAvi;
+    private Button _openAvatarSwitch, _removeLeash, _beep, _vibrate, _shock, _switchToMyAvi;
 
     //Individual Pet Controls
     public SliderFloat StrengthIPC;
@@ -116,8 +116,8 @@ public class IndividualPetControl : ITWManager
         _switchToMyAvi.OnPress += SwitchToMyAvatar;
         _petAvatarListCat = _avatarSwitchingPage.AddCategory("Switchable Avatars", true, false);
 
-        _removeLeashes = controls.AddButton("Remove Leashes", "TWClose", "Remove all leashes connected to you");
-        _removeLeashes.OnPress += LeadManager.RemoveLeashIPC;
+        _removeLeash = controls.AddButton("Remove Leash", "TWClose", "Remove this pets leash");
+        _removeLeash.OnPress += LeadManager.RemoveLeashIPC;
 
         LeadManager.Instance.TetherRangeIPC =
             controls.AddSlider("Leash Length", "Adjust the length of this pets leash", 2f, 0f, 10f);

--- a/TotallyWholesome/Managers/TWUI/Pages/Shocker/PiShockPage.cs
+++ b/TotallyWholesome/Managers/TWUI/Pages/Shocker/PiShockPage.cs
@@ -63,11 +63,17 @@ public static class PiShockPage
         foreach (var (key, value) in PiShockConfig.Config.Shockers)
         {
             var button =
-                _shockersCategory.AddButton(key, value.Enabled ? "ToggleOn" : "ToggleOff", "Open Shocker Settings");
+                _shockersCategory.AddButton(key, value.Enabled ? "ToggleOn" : "ToggleOff", "Toggle Shocker Enablement");
             if (shockersInfos.TryGetValue(key, out var info))
             {
                 button.ButtonText = info.Name;
             }
+            button.OnPress += () =>
+            {
+                value.Enabled = !value.Enabled;
+                button.ButtonIcon = value.Enabled ? "ToggleOn" : "ToggleOff";
+                PiShockConfig.SaveFnF();
+            };
         }
     }
 

--- a/TotallyWholesome/Managers/TWUI/Pages/Shocker/ShockerPage.cs
+++ b/TotallyWholesome/Managers/TWUI/Pages/Shocker/ShockerPage.cs
@@ -65,7 +65,7 @@ public static class ShockerPage
         _intensityLimit.OnValueUpdated += f => _shockerConfig.LimitIntensity = Convert.ToByte(f);
 
         _durationLimit = shockerPermsAndLimits.AddSlider("Duration Limit",
-            "The maximum intensity this shocker can go to",
+            "The maximum duration this shocker can go to",
             0, 0, 15);
         _durationLimit.OnValueUpdated += f => _shockerConfig.LimitDuration = Convert.ToUInt16(f * 1000);
 

--- a/TotallyWholesome/Managers/TWUI/Pages/TWSettingsUI.cs
+++ b/TotallyWholesome/Managers/TWUI/Pages/TWSettingsUI.cs
@@ -242,7 +242,7 @@ public class TWSettingsUI : ITWManager
             {
                 var category = TWMenu.Categories[$"User{attribute.Category}"];
                 var toggle = category.AddToggle(attribute.Name, attribute.DescriptionUser, ConfigManager.Instance.IsActive(accessType));
-                toggle.OnValueUpdated += b => { ConfigManager.Instance.SetActive(accessType, b, toggle); };
+                toggle.OnValueUpdated += b => { ConfigManager.Instance.SetActive(accessType, b, toggle, QuickMenuAPI.SelectedPlayerID); };
                 _userPermsToggles.Add(accessType.ToString(), toggle);
             }
         }


### PR DESCRIPTION
- Fixs the user settings menu changing global settings instead
- Allows pishock shockers to be enabled/disabled individually from the menu
- Don't use disabled pishock shockers
- Restored random shocker mode for pishock
- Corrected several akwardly worded or incorrect strings