### PR TITLE
Fix disconnect and join home world, individual pet control, add name to notification

### DIFF
--- a/TotallyWholesome/Managers/Lead/LeadManager.cs
+++ b/TotallyWholesome/Managers/Lead/LeadManager.cs
@@ -385,6 +385,7 @@ namespace TotallyWholesome.Managers.Lead
             
             Main.Instance.MainThreadQueue.Enqueue(() =>
             {
+                var requester = TWUtils.GetPlayerFromPlayerlist(packet.RequesterID);
 
                 if ((ConfigManager.Instance.IsActive(AccessType.AutoAcceptFriendsOnly) && Friends.FriendsWith(packet.RequesterID)) ||
                     !ConfigManager.Instance.IsActive(AccessType.AutoAcceptFriendsOnly))
@@ -392,13 +393,12 @@ namespace TotallyWholesome.Managers.Lead
                     if (ConfigManager.Instance.IsActive(AccessType.AutoAcceptMasterRequest, packet.RequesterID))
                     {
                         Con.Debug("Auto accepted master request");
-                        NotificationSystem.EnqueueNotification("Totally Wholesome", "You have auto accepted a master request!", 4f, TWAssets.Crown);
+                        NotificationSystem.EnqueueNotification("Totally Wholesome", $"You have auto accepted a master request from {requester.Username}!", 4f, TWAssets.Crown);
                         TWNetSendHelpers.AcceptMasterRequest(packet.Key, packet.RequesterID);
                         return;
                     }
                 }
 
-                var requester = TWUtils.GetPlayerFromPlayerlist(packet.RequesterID);
                 _pendingRequest = packet;
                 _petRequest = false;
                 
@@ -412,6 +412,7 @@ namespace TotallyWholesome.Managers.Lead
 
             Main.Instance.MainThreadQueue.Enqueue(() =>
             {
+                var requester = TWUtils.GetPlayerFromPlayerlist(packet.RequesterID);
 
                 if ((ConfigManager.Instance.IsActive(AccessType.AutoAcceptFriendsOnly) && Friends.FriendsWith(packet.RequesterID)) ||
                     !ConfigManager.Instance.IsActive(AccessType.AutoAcceptFriendsOnly))
@@ -419,13 +420,12 @@ namespace TotallyWholesome.Managers.Lead
                     if (ConfigManager.Instance.IsActive(AccessType.AutoAcceptPetRequest, packet.RequesterID))
                     {
                         Con.Debug("Auto accepted pet request");
-                        NotificationSystem.EnqueueNotification("Totally Wholesome", "You have auto accepted a pet request!", 4f, TWAssets.Handcuffs);
+                        NotificationSystem.EnqueueNotification("Totally Wholesome", $"You have auto accepted a pet request from {requester.Username}!", 4f, TWAssets.Handcuffs);
                         TWNetSendHelpers.AcceptPetRequest(packet.Key, packet.RequesterID);
                         return;
                     }
                 }
 
-                var requester = TWUtils.GetPlayerFromPlayerlist(packet.RequesterID);
                 _pendingRequest = packet;
                 _petRequest = true;
                 

--- a/TotallyWholesome/Managers/TWUI/Pages/IndividualPetControl.cs
+++ b/TotallyWholesome/Managers/TWUI/Pages/IndividualPetControl.cs
@@ -30,7 +30,6 @@ public class IndividualPetControl : ITWManager
 
     public LeadPair SelectedLeadPair;
     public string SelectedPetName, SelectedPetID;
-    public ToggleButton GagPet, HeightControl;
     public Dictionary<string, Button> PetButtons = new();
 
     //Achievement vars
@@ -56,6 +55,7 @@ public class IndividualPetControl : ITWManager
     //Individual Pet Controls
     public SliderFloat StrengthIPC;
     public SliderFloat DurationIPC;
+    public ToggleButton HeightControl;
     public SliderFloat ShockHeightIPC;
     public SliderFloat ShockHeightStrengthMinIPC;
     public SliderFloat ShockHeightStrengthMaxIPC;
@@ -413,7 +413,6 @@ public class IndividualPetControl : ITWManager
 
     private void UpdateIPCPage()
     {
-        GagPet.ToggleValue = SelectedLeadPair.ForcedMute;
         HeightControl.ToggleValue = SelectedLeadPair.Shocker.HeightControl.Enabled;
         LeadManager.Instance.TetherRangeIPC.SetSliderValue(SelectedLeadPair.LeadLength);
         ButtplugManager.Instance.ToyStrengthIPC.SetSliderValue(SelectedLeadPair.ToyStrength);

--- a/TotallyWholesome/Network/TWNetClient.cs
+++ b/TotallyWholesome/Network/TWNetClient.cs
@@ -431,6 +431,9 @@ namespace TotallyWholesome.Network
 
             if (_connectedToGS)
                 return;
+            
+            if (MetaPort.Instance.IsHomeInstance)
+                return;
 
             _connectedToGS = true;
 


### PR DESCRIPTION
- Fixed a bug when using disconnect and join home world from an online instance causing tw to use the old instance id in the next instance you join
- Fixed a NullReferenceException when selecting a pet in individual pet control
- Added the name of the master/pet you just auto-accepted from in the notification